### PR TITLE
Alert posthook option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4-alpine3.18 AS builder
+FROM golang:1.23-alpine3.20 AS builder
 
 WORKDIR /src
 
@@ -8,7 +8,7 @@ RUN GOOS=linux GOARCH=amd64 go build -o /idly /src/cmd/idlyd/main.go
 
 # -----
 
-FROM alpine:3.18
+FROM alpine:3.20
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ default 720h (30 days)
 * `ALERT_EMAIL_FROM` from who will the service send the email, 
 * `ALERT_EMAIL_TITLE` The title of the email as a go template. default `[{{.Service}}]: Your {{.Service}} account has been accessed from a new IP Address`
 * `ALERT_EMAIL_TEMPLATE` The path to a file containing a template for the email.
+* `ALERT_EMAIL_POSTHOOK` HTTP endpoint to be called when alerting instead of sending an email.
 
 * `MMAILER_URL` MMailer API base URL (https://github.com/modfin/mmailer)
 * `MMAILER_KEY` MMailer API key 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/modfin/idly
 
-go 1.20
+go 1.23
 
 require (
 	github.com/caarlos0/env/v9 v9.0.0

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -118,7 +118,7 @@ func Start(c context.Context, db dao.DAO) {
 		}
 
 		log.Println(fmt.Sprintf("Current login: %v", login))
-		log.Println(fmt.Sprintf("Previous logins: %v", logins))
+		log.Println(fmt.Sprintf("Previous logins: %d", len(logins)))
 
 		err = db.StoreLogin(login, config.Get().LoginTTL)
 		if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	AlertFromEmail     string `env:"ALERT_EMAIL_FROM"`
 	AlertEmailTitle    string `env:"ALERT_EMAIL_TITLE" envDefault:"[{{.Service}}]: Your {{.Service}} account has been accessed from a new IP Address"`
 	AlertEmailTemplate string `env:"ALERT_EMAIL_TEMPLATE,file"`
+	AlertEmailPosthook string `env:"ALERT_EMAIL_POSTHOOK"`
 
 	MMailerURL string `env:"MMAILER_URL"`
 	MMailerKey string `env:"MMAILER_KEY"`

--- a/models.go
+++ b/models.go
@@ -41,3 +41,15 @@ func (l Login) Value() (string, error) {
 	b, err := json.Marshal(l)
 	return string(b), err
 }
+
+type AlertInfo struct {
+	Service   string    `json:"service,omitempty"`
+	UID       string    `json:"uid,omitempty"`
+	Location  string    `json:"location,omitempty"`
+	At        time.Time `json:"at"`
+	Device    string    `json:"device"`
+	IPAddress string    `json:"ip_address"`
+	UserAgent string    `json:"user_agent"`
+	Email     string    `json:"email"`
+	Subject   string    `json:"subject"`
+}


### PR DESCRIPTION
Added the option to provide a posthook. If used, Idly will instead send the payload to the posthook rather than populating the default template and sending the alert by mail to the user.

This makes it possible for the calling service to take control of alert action and templating of content.

Also bumped go to 1.23